### PR TITLE
Working se 04 bastion changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@
 # Secret File
 secret_env_vars.*
 secret_env_vars
+EBusinessSuite/graph.png
+EBusinessSuite/graph.dot
+EBusinessSuite/graph.gml
+EBusinessSuite/graph.dot.fixed.txt
+EBusinessSuite/graph.dot.fixed.Novars.txt
+EBusinessSuite/graph.dot.fixed.Novars.Nolocals.txt
+EBusinessSuite/graph.dot.fixed.Novars.Nolocals.NoOutput.txt

--- a/EBusinessSuite/Setup.README.txt
+++ b/EBusinessSuite/Setup.README.txt
@@ -1,33 +1,57 @@
-REM Use these variables for a quick run of EBS main.tf
-REM
-REM  ** need to fix these two, after signing in via CLI
-REM    az login
-REM    az account set --subscription 999902f0-e209-4f0d-a253-4b86032eac0e
-
+@REM Use these variables for a quick run of EBS main.tf
+@REM ============================================================
+@REM  You need to authentication using the CLI before 
+@REM  running Terraform plan or apply.  e.g.,
+@REM    az login
+@REM    az account set --subscription 999902f0-e209-4f0d-a253-4b86032eac0e
+@REM
+@REM ============================================================
+@REM The following are likely to need modification for your testing.
+@REM The tenant ID will be returned in the "az login" result above.
+@REM
 SET TF_VAR_subscription_id=999902f0-e209-4f0d-a253-4b86032eac0e
 SET TF_VAR_tenant_id=72f988bf-aaaa-41af-91ab-2d7cd011db47
-
+@REM
+@REM SSH settings for the VMs
+@REM The templates expect that you'll have a key file (defaulting to the same 
+@REM  "~/.ssh/id_rsa.pub" for both bastion and others).  If you want to override
+@REM  the path(es) define the following variables to point to the desired file(s).
+@REM
+@REM SET TF_VAR_compute_ssh_public_key=c:/users/%USERNAME%/documents/Test1.public.ppk
+@REM SET TF_VAR_bastion_ssh_public_key=c:/users/%USERNAME%/documents/Test1.public.ppk
+@REM
+@REM ============================================================
+@REM ==  Items below here will likely not require adjustment to execute the templates.
+@REM
+@REM  The script will push in some data via CustomData.  For now, this can be anything.
+SET TF_VAR_custom_data=#!/bin/sh
+@REM
 SET TF_VAR_client_id=abc
 SET TF_VAR_client_secret=def
-SET TF_VAR_db_offer=abc
-SET TF_VAR_db_publisher=abc
-SET TF_VAR_db_sku=abc
-SET TF_VAR_db_version=abc
-SET TF_VAR_location="EastUS"
-SET TF_VAR_environment=test
-SET TF_VAR_number_of_instances=2
-SET TF_VAR_resource_group_name="AAA5"
-SET TF_VAR_vm_admin_password=!!abc9545
-SET TF_VAR_vm_admin_username=cuser
-SET TF_VAR_custom_data=SomeCustomDataValue
+@REM Image selection for the Application and Bastion
 SET TF_VAR_vm_os_offer=abc
 SET TF_VAR_vm_os_publisher=abc
 SET TF_VAR_vm_os_sku=abc
 SET TF_VAR_vm_os_version=abc
 SET TF_VAR_vm_sku=Standard_DS1_v2
+SET TF_VAR_environment=test
+SET TF_VAR_number_of_instances=2
+@REM
+@REM Image selection for the database VM
+SET TF_VAR_db_offer=abc
+SET TF_VAR_db_publisher=abc
+SET TF_VAR_db_sku=abc
+SET TF_VAR_db_version=abc
+@REM
+@REM currently VMs are only SSH access, but user/pw included for now.
+SET TF_VAR_admin_password=!!abc9545ABC9545
+SET TF_VAR_admin_username=cuser
+@REM Housekeeping
+SET TF_VAR_resource_group_name="AAA5"
+SET TF_VAR_location="EastUS"
+@REM
+@REM Network config
 SET TF_VAR_vnet_cidr=10.0.0.0/16
 SET TF_VAR_vnet_name=EBSVN3
-REM
-REM Need to create a key file to sit in this directory
-SET TF_VAR_compute_ssh_public_key=c:/users/%USERNAME%/documents/.ssh/Test1.public.ppk
-
+@REM
+@REM Finis

--- a/EBusinessSuite/main.tf
+++ b/EBusinessSuite/main.tf
@@ -41,6 +41,12 @@ locals {
             destination_port_ranges = "8000" 
             destination_address_prefix = "*"             
         },
+        {   #TODO: Likely only one of 8000 or 8888 needed..
+            source_port_ranges =  "*" 
+            source_address_prefix = "AzureLoadBalancer"  # input from the Load Balancer only.             
+            destination_port_ranges = "8888" 
+            destination_address_prefix = "*"             
+        },
         {
             source_port_ranges =  "*" 
             source_address_prefix = "${local.subnetPrefixes["bastion"]}"  # input from the Load Balancer only.               
@@ -158,6 +164,20 @@ module "create_subnets" {
              module.create_networkSGsForApplication.nsg_id))}"
 }
 
+
+###################################################
+# Create a Storage account ofr Boot diagnostics 
+# information for all VMs.
+
+module "create_boot_sa" {
+  source  = "./modules/storage"
+
+  resource_group_name       = "${azurerm_resource_group.rg.name}"
+  location                  = "${var.location}"
+  tags                      = "${var.tags}"
+  compute_hostname_prefix   = "${var.compute_hostname_prefix_app}"
+}
+
 ###################################################
 # Create bastion host
 
@@ -182,8 +202,8 @@ module "create_bastion" {
   bastion_ssh_public_key    = "${var.bastion_ssh_public_key}"
   enable_accelerated_networking     = "${var.enable_accelerated_networking}"
   vnet_subnet_id            = "${module.create_subnets.subnet_ids["bastion"]}"
+  boot_diag_SA_endpoint     = "${module.create_boot_sa.boot_diagnostics_account_endpoint}"
 }
-
 
 ###################################################
 # Create Application server
@@ -211,6 +231,7 @@ module "create_app" {
   enable_accelerated_networking     = "${var.enable_accelerated_networking}"
   vnet_subnet_id            = "${module.create_subnets.subnet_ids["application"]}"
   backendpool_id            = "${module.lb.backendpool_id}"
+  boot_diag_SA_endpoint     = "${module.create_boot_sa.boot_diagnostics_account_endpoint}"  
 }
 
 ###################################################

--- a/EBusinessSuite/modules/bastion/bastion.tf
+++ b/EBusinessSuite/modules/bastion/bastion.tf
@@ -1,20 +1,18 @@
-resource "random_id" "vm-sa" {
-  keepers = {
-      tmp = "${var.compute_hostname_prefix_bastion}"
-  }
-
-  byte_length = 8
-}
-
-resource "azurerm_storage_account" "vm-sa" {
-  name                     = "bootdiag${lower(random_id.vm-sa.hex)}"
-  resource_group_name      = "${var.resource_group_name}"
-  location                 = "${var.location}"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  tags                     = "${var.tags}"
-}
-
+#resource "random_id" "vm-sa" {
+#  keepers = {
+#      tmp = "${var.compute_hostname_prefix_bastion}"
+#  }
+#
+#  byte_length = 8
+#}
+#resource "azurerm_storage_account" "vm-sa" {
+#  name                     = "bootdiag${lower(random_id.vm-sa.hex)}"
+#  resource_group_name      = "${var.resource_group_name}"
+#  location                 = "${var.location}"
+#  account_tier             = "Standard"
+#  account_replication_type = "LRS"
+#  tags                     = "${var.tags}"
+#}
 
 resource "azurerm_virtual_machine" "bastion" {
   name                          = "${var.compute_hostname_prefix_bastion}-${format("%.02d",count.index + 1)}"
@@ -61,11 +59,9 @@ resource "azurerm_virtual_machine" "bastion" {
 
   boot_diagnostics {
     enabled     = "true"
-    storage_uri = "${azurerm_storage_account.vm-sa.primary_blob_endpoint}"
-    # storage_uri = "${join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint)}"}
+    storage_uri = "${var.boot_diag_SA_endpoint}"
   }
 }
-
 
 resource "azurerm_network_interface" "bastion" {
   name                          = "${var.compute_hostname_prefix_bastion}-${format("%.02d",count.index + 1)}-nic"  

--- a/EBusinessSuite/modules/bastion/bastion.variables.tf
+++ b/EBusinessSuite/modules/bastion/bastion.variables.tf
@@ -57,3 +57,8 @@ variable "public_ip_address_allocation" {
   description = "(Required) Defines how an IP address is assigned. Options are Static or Dynamic."
   default = "Static"
 }
+
+variable "boot_diag_SA_endpoint" {
+  description = "Blob endpoint for storage account to use for VM Boot diagnostics"
+  type = "string"
+}

--- a/EBusinessSuite/modules/compute/compute.tf
+++ b/EBusinessSuite/modules/compute/compute.tf
@@ -1,19 +1,4 @@
-resource "random_id" "vm-sa" {
-  keepers = {
-      tmp = "${var.compute_hostname_prefix_app}"
-  }
-
-  byte_length = 8
-}
-
-resource "azurerm_storage_account" "vm-sa" {
-  name                     = "bootdiag${lower(random_id.vm-sa.hex)}"
-  resource_group_name      = "${var.resource_group_name}"
-  location                 = "${var.location}"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  tags                     = "${var.tags}"
-}
+#  Provision Application VMs
 
 resource "azurerm_virtual_machine" "compute" {
   name                          = "${var.compute_hostname_prefix_app}-${format("%.02d",count.index + 1)}"
@@ -69,9 +54,9 @@ resource "azurerm_virtual_machine" "compute" {
 
   boot_diagnostics {
     enabled     = "true"
-    storage_uri = "${azurerm_storage_account.vm-sa.primary_blob_endpoint}"
-    # storage_uri = "${join(",", azurerm_storage_account.vm-sa.*.primary_blob_endpoint)}"}
+    storage_uri = "${var.boot_diag_SA_endpoint}"
   }
+
 }
 
 resource "azurerm_availability_set" "compute" {

--- a/EBusinessSuite/modules/compute/compute.variables.tf
+++ b/EBusinessSuite/modules/compute/compute.variables.tf
@@ -55,6 +55,11 @@ variable "enable_accelerated_networking" {
 variable "vnet_subnet_id" {
 }
 
+variable "boot_diag_SA_endpoint" {
+  description = "Blob endpoint for storage account to use for VM Boot diagnostics"
+  type = "string"
+}
+
 #TODO
 /*
 variable "network_security_group_id" {

--- a/EBusinessSuite/modules/load_balancer/lb.outputs.tf
+++ b/EBusinessSuite/modules/load_balancer/lb.outputs.tf
@@ -1,4 +1,4 @@
 output "backendpool_id" {
-    description = "Backend pool"
+    description = "Backend pool id"
     value = "${azurerm_lb_backend_address_pool.azlb.id}"
 }

--- a/EBusinessSuite/modules/load_balancer/lb.variables.tf
+++ b/EBusinessSuite/modules/load_balancer/lb.variables.tf
@@ -29,11 +29,6 @@ variable "lb_probe_interval" {
   default     = 5
 }
 
-variable "frontend_name" {
-  description = "(Required) Specifies the name of the frontend ip configuration."
-  default = "app-lb"
-}
-
 variable "public_ip_address_allocation" {
   description = "(Required) Defines how an IP address is assigned. Options are Static or Dynamic."
   default = "Static"

--- a/EBusinessSuite/modules/storage/storage.outputs.tf
+++ b/EBusinessSuite/modules/storage/storage.outputs.tf
@@ -1,0 +1,9 @@
+output "boot_diagnostics_account_name" {
+    description = "Name of created storage account"
+    value = "${azurerm_storage_account.vm-sa.name}"
+}
+
+output "boot_diagnostics_account_endpoint" {
+    description = "Blob endpoint for boot diagnostics storage account"
+    value = "${azurerm_storage_account.vm-sa.primary_blob_endpoint}"
+}

--- a/EBusinessSuite/modules/storage/storage.tf
+++ b/EBusinessSuite/modules/storage/storage.tf
@@ -1,0 +1,20 @@
+#
+#  Create a storage account for boot diagnostics.
+#
+
+resource "random_id" "vm-sa" {
+  keepers = {
+      tmp = "${var.compute_hostname_prefix}"
+  }
+
+  byte_length = 8
+}
+
+resource "azurerm_storage_account" "vm-sa" {
+  name                     = "bootdiag${lower(random_id.vm-sa.hex)}"
+  resource_group_name      = "${var.resource_group_name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  tags                     = "${var.tags}"
+}

--- a/EBusinessSuite/modules/storage/storage.variables.tf
+++ b/EBusinessSuite/modules/storage/storage.variables.tf
@@ -1,0 +1,21 @@
+variable "resource_group_name" {
+}
+variable "location" {
+}
+variable "tags" {
+  type = "map"
+
+  default = {
+    application = "Oracle EBusinessSuite"
+  }
+}
+
+variable "diag_storage_account_tier" {
+    description = "Tier for boot diagnostics account.  One of 'Standard' or 'Premium'"
+    default = "Standard"
+}
+
+variable "compute_hostname_prefix" {
+    description = "Name prefix used for app VMs -- an anchor to generate the SA name"
+    type = "string"
+}


### PR DESCRIPTION
1.  Naming changes 
    - Adjusted bastion processing to normalize names
    - LB naming changed to reflect it's the app lb
    - Removed LB frontend_name var for lb.tf as it's an internal detail.
5. Added rule in main.tf for LB->App target port 8888 -- now we have 8000 and 8888, should pick the right one.
2. Move random provider use for boot diag storage account to a storage module to let us use a single account for all of the VMs.
    - boot diag storage account has to be LRS, so no need for a variable.
4. Fixed Setup file to include new variables needed to test.




